### PR TITLE
Resolve GH-12

### DIFF
--- a/lib/baker.js
+++ b/lib/baker.js
@@ -93,7 +93,7 @@ exports.bake = function bake(assertionUrl, options, callback) {
           if (error)
             return callback({
               error: "processing",
-              reason: "Could not write data to png: " + e.message
+              reason: "Could not write data to png: " + error.message
             });
           workspace.baked = {
             imgData: imgData


### PR DESCRIPTION
Resolve issue where error message is referencing `e` which does not exist. Resolves GH-12
